### PR TITLE
Bugfix/linphone daemon

### DIFF
--- a/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk.bb
+++ b/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk.bb
@@ -16,7 +16,8 @@ python () {
     print(d.getVar('SRCREV', True))
 }
 
-SRC_URI = "gitsm://gitlab.linphone.org/BC/public/linphone-sdk.git;protocol=https;branch=release/5.0;"
+SRC_URI  = "gitsm://gitlab.linphone.org/BC/public/linphone-sdk.git;protocol=https;branch=release/5.0;"
+SRC_URI += "file://call-stats.patch"
 
 PV = "git_${SRCREV}"
 PKGV = "${GITPKGVTAG}"

--- a/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk/call-stats.patch
+++ b/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk/call-stats.patch
@@ -1,0 +1,10 @@
+--- linphone-sdk/liblinphone/daemon/commands/call-stats.cc	2021-10-10 19:04:26.305172757 +0200
++++ linphone-sdk/liblinphone/daemon/commands/call-stats.cc.new	2021-10-10 19:03:35.268962507 +0200
+@@ -74,6 +74,6 @@
+ 
+ 	ostringstream ostr;
+ 	ostr << CallStatsEvent(app, call, linphone_call_get_audio_stats(call)).getBody();
+-	ostr << CallStatsEvent(app, call, linphone_call_get_video_stats(call)).getBody();
++	// ostr << CallStatsEvent(app, call, linphone_call_get_video_stats(call)).getBody();
+ 	app->sendResponse(Response(ostr.str(), Response::Ok));
+ }

--- a/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk/call-stats.patch
+++ b/recipes-bc/linphone-sdk/linphone-sdk/linphone-sdk/call-stats.patch
@@ -1,10 +1,20 @@
---- linphone-sdk/liblinphone/daemon/commands/call-stats.cc	2021-10-10 19:04:26.305172757 +0200
-+++ linphone-sdk/liblinphone/daemon/commands/call-stats.cc.new	2021-10-10 19:03:35.268962507 +0200
-@@ -74,6 +74,6 @@
+--- linphone-sdk/liblinphone/daemon/commands/call-stats.cc	2021-10-10 19:26:55.499286281 +0200
++++ linphone-sdk/liblinphone/daemon/commands/call-stats.cc.new	2021-10-10 19:26:51.799270213 +0200
+@@ -73,7 +73,15 @@
+ 	}
  
  	ostringstream ostr;
- 	ostr << CallStatsEvent(app, call, linphone_call_get_audio_stats(call)).getBody();
+-	ostr << CallStatsEvent(app, call, linphone_call_get_audio_stats(call)).getBody();
 -	ostr << CallStatsEvent(app, call, linphone_call_get_video_stats(call)).getBody();
-+	// ostr << CallStatsEvent(app, call, linphone_call_get_video_stats(call)).getBody();
++
++	LinphoneCallStats* stats = nullptr;
++	stats = linphone_call_get_audio_stats(call);
++	if (nullptr != stats) {
++		ostr << CallStatsEvent(app, call, stats).getBody();
++	}
++	stats = linphone_call_get_video_stats(call);
++	if (nullptr != stats) {
++		ostr << CallStatsEvent(app, call, stats).getBody();
++	}
  	app->sendResponse(Response(ostr.str(), Response::Ok));
  }


### PR DESCRIPTION
Applies patches to linphone-daemon cli command "call-stats". The upstream implementation appears to naively expect each call to have both an audio and video component. When linphone performs a lookup for the video component this returns a nullptr (since our calls only use an audio component).

This nullptr is then passed to the ctor for CallStatsEvent where it is eventually dereferenced in subsequent calls causing a segfault.

This PR pushes two patches - the first one only comments out the code and the second one is a little bit more intricate where an explicit nullcheck is performed instead.

An issue has been created in the upstream repo for tracking:

https://github.com/BelledonneCommunications/linphone-sdk/issues/183
